### PR TITLE
Add TTA ability to inference function

### DIFF
--- a/Inference.py
+++ b/Inference.py
@@ -67,7 +67,6 @@ def inference(model: torch.nn.Module,
     num_iters = 1 if tta_num_iters == 0 else tta_num_iters
 
     y_scores = np.zeros((len(models), len(dataset), num_iters))
-    print(y_scores.shape)
 
     for i, model_checkpoint in enumerate(models):
         state_dict = torch.load(f'{checkpoint_path}/{model_checkpoint}')


### PR DESCRIPTION
This PR adds the ability to use test time augmentation at inference time.

Results showed that it did not lead to any improvement, but just adding so we have the ability to use it if we want. 

zenhub issue: https://app.zenhub.com/workspaces/allensdk-10-5c17f74db59cfb36f158db8c/issues/alleninstitute/ophys_etl_pipelines/358