### PR TITLE
ticket-27: Add Split by Depth/3P/"Problem Exp" logic to DataSplitter class

### DIFF
--- a/src/deepcell/cli/schemas/data.py
+++ b/src/deepcell/cli/schemas/data.py
@@ -1,4 +1,3 @@
-import json
 import os.path
 from pathlib import Path
 
@@ -7,6 +6,7 @@ import marshmallow
 from marshmallow.validate import OneOf
 
 from deepcell.datasets.model_input import ModelInput
+from deepcell.datasets.exp_metadata import ExperimentMetadata
 
 
 class ModelInputSchema(argschema.ArgSchema):
@@ -53,6 +53,32 @@ class ModelInputSchema(argschema.ArgSchema):
                     data[k] = Path(v)
 
         return ModelInput(**data)
+
+
+class ExperimentMetadataSchema(argschema.ArgSchema):
+    """Defines metadata for experiments"""
+    experiment_id = argschema.fields.String(
+        required=True,
+        description='experiment_id'
+    )
+    imaging_depth = argschema.fields.Int(
+        required=True,
+        description='Depth of the experiment'
+    )
+    equipment = argschema.fields.String(
+        required=True,
+        description='Name of the equipment doing data acquisition.',
+    )
+    problem_experiment = argschema.fields.Bool(
+        required=True,
+        description='Marker that the experiment is special and should be '
+                    'considered a unique sample.',
+    )
+
+    @marshmallow.post_load
+    def make_experiment_metadata(self, data):
+        data = {k: v for k, v in data.items() if k not in ('log_level',)}
+        return ExperimentMetadata(**data)
 
 
 class DataSchema(argschema.ArgSchema):

--- a/src/deepcell/data_splitter.py
+++ b/src/deepcell/data_splitter.py
@@ -1,16 +1,19 @@
-from typing import List, Optional, Generator, Tuple, Iterator
+from typing import List, Optional, Tuple, Iterator
 
 import numpy as np
 from sklearn.model_selection import StratifiedShuffleSplit, StratifiedKFold
 
 from deepcell.datasets.model_input import ModelInput
 from deepcell.datasets.roi_dataset import RoiDataset
-from deepcell.datasets.visual_behavior_dataset import VisualBehaviorDataset
+from deepcell.datasets.exp_metadata import ExperimentMetadata
 from deepcell.transform import Transform
 
 
 class DataSplitter:
-    def __init__(self, model_inputs: List[ModelInput], train_transform=None,
+    def __init__(self,
+                 model_inputs: List[ModelInput],
+                 experiment_metadatas: List[ExperimentMetadata],
+                 train_transform=None,
                  test_transform=None, seed=None,
                  cre_line=None, exclude_mask=False,
                  mask_out_projections=False, image_dim=(128, 128),
@@ -24,6 +27,8 @@ class DataSplitter:
         Args:
             model_inputs:
                 List of model inputs
+            experiment_metadatas:
+                List of experiment metadata.
             train_transform:
                 Transforms to apply to training data
             test_transform:
@@ -53,6 +58,7 @@ class DataSplitter:
                 `deepcell.datasets.util.calc_roi_centroid`
         """
         self._model_inputs = model_inputs
+        self._exp_metas = experiment_metadatas
         self.train_transform = train_transform
         self.test_transform = test_transform
         self.seed = seed
@@ -65,33 +71,138 @@ class DataSplitter:
         self._centroid_use_mask = centroid_use_mask
 
         if center_roi_centroid not in ('test', True, False):
-            raise ValueError(f'Invalid value for center_soma. Valid '
-                             f'values are "test", True, or False')
+            raise ValueError('Invalid value for center_soma. Valid '
+                             'values are "test", True, or False')
         self._center_roi_centroid = center_roi_centroid
 
-    def get_train_test_split(self, test_size):
-        full_dataset = RoiDataset(
-            model_inputs=self._model_inputs,
-            cre_line=self.cre_line,
-            mask_out_projections=self.mask_out_projections,
-            image_dim=self.image_dim,
-            use_correlation_projection=self._use_correlation_projection
-        )
-        sss = StratifiedShuffleSplit(n_splits=2, test_size=test_size,
+    @staticmethod
+    def _get_experiment_groups_for_stratified_split(
+            experiment_metadatas: List[ExperimentMetadata],
+            exp_ids: np.ndarray,
+            n_depth_bins: int):
+        """Bin up input experiment data into bins of depth and "problem"
+        experiments.
+
+        Parameters
+        ---------
+        experiment_metadatas : List[ExperimentMetadata]
+            Set of experiment metadatas to stratify.
+        exp_ids : np.ndarray
+            Array of input experiment ids. Must have same order as
+            ``experiment_metadatas``.
+        n_depth_bins
+            Number of of bins to split by experiment depth. Bins are
+            selected to have an equal number of experiments in each bin.
+
+        Returns
+        -------
+        exp_bin_ids : numpy.ndarray
+           Bin assigned to each experiment id.
+        """
+        # Create the arrays we will use to bin. -1 for a bin_id denotes
+        # an experiment that has not been assigned to a bit yet.
+        exp_bin_ids = np.full(len(experiment_metadatas), -1, dtype=int)
+        depths = np.empty(len(experiment_metadatas), dtype=int)
+
+        for idx, exp_meta in enumerate(experiment_metadatas):
+            # Check for any "special" experiments that we want to partition
+            # separately. This can be anything from identifying a set that have
+            # problematic segmentation or have some other special attribute
+            # we would like to sample fairly in the train/test split.
+            if exp_meta['problem_experiment']:
+                exp_bin_ids[idx] = 0
+            depths[idx] = exp_meta['imaging_depth']
+
+        # Create linear spaced bins from min->max depth. Bin indexes start
+        # from 1 to n_depth_bins.
+        bin_edges = np.linspace(depths[exp_bin_ids < 0].min() - 1e-8,
+                                depths[exp_bin_ids < 0].max() + 1e-8,
+                                n_depth_bins + 1)
+        bin_ids = np.digitize(depths[exp_bin_ids < 0], bin_edges)
+        exp_bin_ids[exp_bin_ids < 0] = bin_ids
+
+        return exp_bin_ids
+
+    @staticmethod
+    def _convert_exp_index_to_roi_index(exp_ids: np.ndarray,
+                                        exp_indices: List[int],
+                                        full_dataset: List[ModelInput]):
+        """Given a set of indices in the the experiment list, find all
+        ROIs that are in the experiments.
+
+        Paramaters
+        ----------
+        exp_ids : np.ndarray
+            Full set of experiment ids
+        exp_indices : List[int]
+            Indexes of selecting experiments in ``exp_ids`` array.
+        full_dataset : List[ModelInput]
+            Set of ROIs for all experiments.
+
+        Returns
+        -------
+        artifacts : List[ModelInput]
+            Subset of ROIs that are within the selected experiments.
+        """
+        selected_experiments = exp_ids[exp_indices]
+        artifacts = []
+        for idx, data in enumerate(full_dataset):
+            if np.isin(int(data.experiment_id), selected_experiments):
+                artifacts.append(idx)
+        return artifacts
+
+    def get_train_test_split(self,
+                             test_size: float,
+                             full_dataset: List[ModelInput],
+                             exp_metas: List[ExperimentMetadata],
+                             depth_bins: int = 5):
+        """Create a train/test split ofROIs by experiment preserving the
+        fraction in bins of depth, experiment type (2P vs 3P), and identified
+        problem/special experiments.
+
+        Parameters
+        ----------
+        test_size : float
+            Percentage of data to reserve for test sample.
+        full_dataset: List[ModelInput]
+            Full set of rois.
+        exp_metas : RoiDataset
+            Set of experiment metadatas to stratify.
+        n_depth_bins
+            Number of of bins to split by experiment depth. Bins are
+            selected to have an equal number of experiments in each bin.
+
+        Returns
+        -------
+        train_test_indices : Tuple[RoiDataset, RoiDataset]
+            Datasets split by train/test.
+        """
+        exp_ids = np.array([int(exp_meta['experiment_id'])
+                            for exp_meta in exp_metas], dtype='uint64')
+        exp_bin_ids = self._get_experiment_groups_for_stratified_split(
+            exp_metas, exp_ids, depth_bins)
+        sss = StratifiedShuffleSplit(n_splits=1,
+                                     test_size=test_size,
                                      random_state=self.seed)
-        train_index, test_index = next(sss.split(np.zeros(len(full_dataset)),
-                                                 full_dataset.y))
+        train_index, test_index = next(sss.split(exp_bin_ids,
+                                                 exp_bin_ids))
 
         train_dataset = self._sample_dataset(
-            dataset=full_dataset.model_inputs,
-            index=train_index,
+            dataset=full_dataset,
+            index=self._convert_exp_index_to_roi_index(
+                exp_ids,
+                train_index,
+                full_dataset),
             transform=self.train_transform,
             is_train=True
         )
 
         test_dataset = self._sample_dataset(
-            dataset=full_dataset.model_inputs,
-            index=test_index,
+            dataset=full_dataset,
+            index=self._convert_exp_index_to_roi_index(
+                exp_ids,
+                test_index,
+                full_dataset),
             transform=self.test_transform,
             is_train=False)
 
@@ -124,14 +235,12 @@ class DataSplitter:
             seed=None) -> Iterator[Tuple[np.ndarray, np.ndarray]]:
         """
         Gets the cross validation split indices
-
         Parameters
         ----------
         model_inputs: List of ModelInput to split
         n_splits: total number of cross validation splits
         shuffle: whether to shuffle before performing the split
         seed: seed for reproducibility of shuffling
-
         Returns
         -------
         yields Tuple of np.ndarray for train and test indices
@@ -149,7 +258,6 @@ class DataSplitter:
                         transform: Optional[Transform] = None) -> \
             RoiDataset:
         """Returns RoiDataset of Artifacts at index
-
         Args:
             dataset:
                 Initial dataset to sample from
@@ -159,7 +267,6 @@ class DataSplitter:
                 Whether this is a train dataset or test dataset
             transform:
                 optional transform to pass to RoiDataset
-
         Returns
             RoiDataset
         """

--- a/src/deepcell/datasets/exp_metadata.py
+++ b/src/deepcell/datasets/exp_metadata.py
@@ -1,0 +1,15 @@
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+
+class ExperimentMetadata(TypedDict):
+    """
+    """
+    experiment_id: str
+    imaging_depth: int
+    equipment: str
+    problem_experiment: bool

--- a/src/deepcell/testing/util.py
+++ b/src/deepcell/testing/util.py
@@ -6,7 +6,10 @@ import numpy as np
 from PIL import Image
 
 
-def get_test_data(write_dir: str, is_train=True) -> List[Dict]:
+def get_test_data(write_dir: str,
+                  is_train: bool = True,
+                  n_rois: int = 10,
+                  exp_mod: int = 2) -> List[Dict]:
     """
 
     Parameters
@@ -15,14 +18,18 @@ def get_test_data(write_dir: str, is_train=True) -> List[Dict]:
         Directory to write test data to
     is_train
         Whether these are train inputs
+    n_rois
+        number of test rois to create.
+    exp_mod
+        Mod value to use to create experiment ids.
 
     Returns
     -------
     dataframe of metadata
     """
-    labels = [random.choice(['cell', 'not cell'])] * 10
+    labels = [random.choice(['cell', 'not cell'])] * n_rois
     dataset = []
-    for i in range(10):
+    for i in range(n_rois):
         img = np.random.randint(low=0, high=255, size=(128, 128),
                                 dtype='uint8')
         with open(Path(write_dir) / f'corr_0_{i}.png', 'wb') as f:
@@ -34,7 +41,7 @@ def get_test_data(write_dir: str, is_train=True) -> List[Dict]:
         with open(Path(write_dir) / f'avg_0_{i}.png', 'wb') as f:
             Image.fromarray(img).save(f)
         d = {
-            'experiment_id': '0',
+            'experiment_id': str(i % exp_mod),
             'roi_id': i,
             'mask_path': str(Path(write_dir) / f'mask_0_{i}.png'),
             'correlation_projection_path': str(Path(write_dir) / f'corr_0_{i}.png'),    # noqa E501
@@ -45,3 +52,25 @@ def get_test_data(write_dir: str, is_train=True) -> List[Dict]:
         dataset.append(d)
 
     return dataset
+
+
+def get_exp_test_data(n_experiments: int = 2) -> List[Dict]:
+    """Create dummy experiments.
+
+    Parameters
+    ----------
+    n_experments
+        Number of unique experiments to create.
+
+    Returns
+    -------
+    exp_meta
+        List of experiment metadatas.
+    """
+    exp_meta = []
+    for exp_id in range(n_experiments):
+        exp_meta.append({'experiment_id': str(exp_id),
+                         'imaging_depth': 0,
+                         'equipment': '2P',
+                         'problem_experiment': False})
+    return exp_meta

--- a/tests/test_data_splitter.py
+++ b/tests/test_data_splitter.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from deepcell.data_splitter import DataSplitter
 from deepcell.datasets.model_input import ModelInput
+from deepcell.datasets.exp_metadata import ExperimentMetadata
 
 
 def test_ids_different():
@@ -13,14 +14,25 @@ def test_ids_different():
     3. Train CV split / Test
     4. Val CV split / Test"""
     model_inputs = [ModelInput(roi_id=f'{i}',
-                               experiment_id='foo',
+                               experiment_id=f'{i%10}',
                                mask_path=Path('foo'),
                                max_projection_path=Path('foo'),
                                avg_projection_path=Path('foo')
                                ) for i in range(5000)]
+    exp_inputs = [ExperimentMetadata(experiment_id=idx,
+                                     imaging_depth=idx % 2,
+                                     equipment='2P',
+                                     problem_experiment=False)
+                  for idx in range(10)]
+
     data_splitter = \
-        DataSplitter(model_inputs=model_inputs, seed=1234)
-    train, test = data_splitter.get_train_test_split(test_size=.3)
+        DataSplitter(model_inputs=model_inputs,
+                     experiment_metadatas=exp_inputs,
+                     seed=1234)
+    train, test = data_splitter.get_train_test_split(test_size=.3,
+                                                     full_dataset=model_inputs,
+                                                     exp_metas=exp_inputs,
+                                                     depth_bins=2)
     assert len(set([x.roi_id for x in train.model_inputs]).intersection(
         [x.roi_id for x in test.model_inputs])) == 0
     for train, val in data_splitter.get_cross_val_split(train_dataset=train):
@@ -36,13 +48,20 @@ def test_dataset_is_shuffled():
     """Tests that when train/test split is performed, the records are
     shuffled"""
     model_inputs = [ModelInput(roi_id=f'{i}',
-                               experiment_id='foo',
+                               experiment_id=f'{i%10}',
                                mask_path=Path('foo'),
                                max_projection_path=Path('foo'),
                                avg_projection_path=Path('foo')
                                ) for i in range(5000)]
+    exp_inputs = [ExperimentMetadata(experiment_id=idx,
+                                     imaging_depth=idx % 2,
+                                     equipment='2P',
+                                     problem_experiment=False)
+                  for idx in range(10)]
     data_splitter = \
-        DataSplitter(model_inputs=model_inputs, seed=1234)
+        DataSplitter(model_inputs=model_inputs,
+                     experiment_metadatas=exp_inputs,
+                     seed=1234)
 
     index = np.random.choice(range(len(model_inputs)), size=100, replace=False)
     dataset = data_splitter._sample_dataset(dataset=model_inputs, index=index,
@@ -51,3 +70,71 @@ def test_dataset_is_shuffled():
     expected_ids = [model_inputs[i].roi_id for i in index]
     actual_ids = [x.roi_id for x in dataset.model_inputs]
     assert expected_ids == actual_ids
+
+
+def test_experiment_binning():
+    """Tests that the code for binning experiment data.
+    """
+    # Just need model inputs for the class init.
+    model_inputs = [ModelInput(roi_id=f'{i}',
+                               experiment_id=f'{i%10}',
+                               mask_path=Path('foo'),
+                               max_projection_path=Path('foo'),
+                               avg_projection_path=Path('foo')
+                               ) for i in range(5)]
+    # Create 2 sets of experiments. 2P at various depths identified as 
+    # special or "problem" experiments and a set of special experiments.
+    n_exp = 4
+    n_depth_bins = 2
+    exp_inputs = [ExperimentMetadata(experiment_id=idx,
+                                     imaging_depth=idx % 4,
+                                     equipment='2P',
+                                     problem_experiment=False)
+                  for idx in range(n_exp)]
+    exp_inputs.extend([ExperimentMetadata(experiment_id=idx,
+                                          imaging_depth=idx,
+                                          equipment='2P',
+                                          problem_experiment=True)
+                       for idx in range(n_exp, 2 * n_exp)])
+
+    data_splitter = \
+        DataSplitter(model_inputs=model_inputs,
+                     experiment_metadatas=exp_inputs,
+                     seed=1234)
+    exp_bin_ids = data_splitter._get_experiment_groups_for_stratified_split(
+        experiment_metadatas=exp_inputs,
+        exp_ids=np.arange(len(exp_inputs), dtype=int),
+        n_depth_bins=n_depth_bins)
+    assert (exp_bin_ids == 0).sum() == n_exp
+    assert (exp_bin_ids == 1).sum() == n_exp / n_depth_bins
+    assert (exp_bin_ids == 2).sum() == n_exp / n_depth_bins
+
+
+def test_convert_exp_index_to_roi_index():
+    """Test that the mapping from selected experiment to ROIs is working as
+    intended.
+    """
+    model_inputs = [ModelInput(roi_id=f'{i}',
+                               experiment_id=f'{i%10}',
+                               mask_path=Path('foo'),
+                               max_projection_path=Path('foo'),
+                               avg_projection_path=Path('foo')
+                               ) for i in range(10)]
+    # Just need some experiment inputs here.
+    exp_inputs = [ExperimentMetadata(experiment_id=idx,
+                                     imaging_depth=idx % 4,
+                                     equipment='2P',
+                                     problem_experiment=False)
+                  for idx in range(10)]
+    expected_exps = np.array([1, 2])
+    data_splitter = \
+        DataSplitter(model_inputs=model_inputs,
+                     experiment_metadatas=exp_inputs,
+                     seed=1234)
+    rois_idxs = data_splitter._convert_exp_index_to_roi_index(
+        exp_ids=np.arange(10, dtype=int),
+        exp_indices=expected_exps,
+        full_dataset=model_inputs)
+    assert len(rois_idxs) == len(expected_exps)
+    assert rois_idxs[0] == 1
+    assert rois_idxs[1] == 2

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -117,4 +117,3 @@ class TestTrainer:
                         [:trainer.early_stopping_callback.best_epoch + 1] ==
                         (trainer_continue._callback_metrics[k]
                         [:trainer.early_stopping_callback.best_epoch + 1]))
-


### PR DESCRIPTION
Tried to hook up everything I could. I wasn't able to find where DataSplitter is instantiated and used outside of notebook so I'm putting at least this code into review with the idea that we may have to ticket some more work to hook up the new Datasplitter.