### PR TITLE
bugfix: name of file output by ophys_etl is prefixed with "correlatio…

### DIFF
--- a/src/deepcell/datasets/model_input.py
+++ b/src/deepcell/datasets/model_input.py
@@ -118,7 +118,7 @@ class ModelInput:
 
         try:
             correlation_projection_path = get_path(data_dir=data_dir,
-                                                   artifact_type='corr',
+                                                   artifact_type='correlation',
                                                    experiment_id=experiment_id,
                                                    roi_id=roi_id)
         except RuntimeError:


### PR DESCRIPTION
…n", not "corr"